### PR TITLE
Add Get Thermostat Status command :GT#

### DIFF
--- a/src/observatory/thermostat/Thermostat.command.cpp
+++ b/src/observatory/thermostat/Thermostat.command.cpp
@@ -37,6 +37,15 @@ bool Thermostat::command(char reply[], char command[], char parameter[], bool *s
         *numericReply = false;
       } else
     #endif
+    //  :GT#  Get Thermostat status
+    //         Example: :GT#
+    //         Returns: 22.3,58.7, temperature in deg. C, humidity in %
+    if (command[1] == 'T' && parameter[0] == 0) {
+      float t = getTemperature();
+      float h = getHumidity();
+      sprintf(reply, "%.1f,%.1f", t, h);
+      *numericReply = false;
+    } else
       return false;
   } else
 

--- a/src/observatory/thermostat/Thermostat.cpp
+++ b/src/observatory/thermostat/Thermostat.cpp
@@ -59,6 +59,14 @@ float Thermostat::getCoolSetpoint() {
   return nv.readF(NV_COOL_SETPOINT);
 }
 
+float Thermostat::getTemperature() {
+  return t1;
+}
+
+float Thermostat::getHumidity() {
+  return thermostatSensor.humidity();
+}
+
 Thermostat thermostat;
 
 #endif

--- a/src/observatory/thermostat/Thermostat.h
+++ b/src/observatory/thermostat/Thermostat.h
@@ -21,6 +21,9 @@ class Thermostat {
     void setCoolSetpoint(float value);
     float getCoolSetpoint();
 
+    float getTemperature();
+    float getHumidity();
+
   private:
     float averageTemperature = NAN;
     float t1 = NAN;


### PR DESCRIPTION
I'm currently writing an Indi driver for the OnCue OCS. While collating the command lexicon I noticed that there was no command to retrieve the current observatory Thermostat readings and I felt this would be a useful addition.
I've added this as command :GT# which returns thermostat temperature and humidity, comma separated and both to one decimal place.
Only tested on OCS4 HW with a BME280, as that's all I have.