### PR TITLE
Fix linker error

### DIFF
--- a/src/lib/axis/motor/servo/dc/Dc.cpp
+++ b/src/lib/axis/motor/servo/dc/Dc.cpp
@@ -125,4 +125,9 @@ void ServoDc::updateStatus() {
   ServoDriver::updateStatus();
 }
 
+// empty calibrate function
+void ServoDc::calibrate() {
+  // do nothing
+}
+
 #endif

--- a/src/lib/axis/motor/servo/dc/Dc.h
+++ b/src/lib/axis/motor/servo/dc/Dc.h
@@ -46,6 +46,8 @@ class ServoDc : public ServoDriver {
 
     const ServoDcSettings *Settings;
 
+    void calibrate();
+
   private:
     // motor control update
     void pwmUpdate(float power);


### PR DESCRIPTION
Commit [0b1775e](https://github.com/hjd1964/OCS/commit/0b1775efd2e613550fc6d5546e62bac69e46dc21) gave me a linker error when using Dc.cpp provided driver models. 
This commit adds a dummy empty ServoDc::calibrate function to Dc.h / Dc.cpp
I'm not sure if this is the cleanest resolution for this error but it works for me.