### PR TITLE
Fix for watchdog

### DIFF
--- a/src/HAL/HAL_Teensy_4.1.h
+++ b/src/HAL/HAL_Teensy_4.1.h
@@ -66,7 +66,7 @@
 
 // Watchdog control macros --------------------------------------------------------------------------
 #if WATCHDOG != OFF
-  #define WDT_ENABLE watchdog.enable(8);
+  #define WDT_ENABLE watchdog.enable(14);
   #define WDT_RESET watchdog.reset();
   #define WDT_DISABLE watchdog.disable();
 #else

--- a/src/lib/watchdog/Watchdog.h
+++ b/src/lib/watchdog/Watchdog.h
@@ -22,7 +22,7 @@ class Watchdog {
 
   private:
     volatile int16_t count = 0;
-    volatile int16_t seconds = 0;
+    volatile int16_t seconds = -1;
     volatile bool enabled = false;
 };
 


### PR DESCRIPTION
Issue [#1](https://github.com/hjd1964/OCS/issues/6).
HW timer was being allocated. Watchdog was never enabled due to `volatile int16_t seconds = 0;` in Watchdog.h and `if (this->seconds == -1) {`  in Watchdog.cpp. I just changed the declaration to -1;
I also found that, at least on my OCS4 HW, the watchdog poll loop started approximately 12 seconds before the watchdog reset loop, therefore I changed the watchdog delay to `#define WDT_ENABLE watchdog.enable(14);` in HAL_Teensy_4.1.h
I also tried the suggested task to call the :SW# lockup loop, which I got working but I still didn't get a command response so I haven't included that.