### PR TITLE
Fixes Teensy 4.1 internal temperature monitoring.

### DIFF
--- a/src/HAL/HAL_Teensy_4.1.h
+++ b/src/HAL/HAL_Teensy_4.1.h
@@ -1,5 +1,6 @@
 // Platform setup ------------------------------------------------------------------------------------
 #pragma once
+extern float tempmonGetTemp(void);
 
 // We define a more generic symbol, in case more Teensy boards based on different lines are supported
 #define __TEENSYDUINO__
@@ -62,7 +63,7 @@
 
 //--------------------------------------------------------------------------------------------------
 // Internal MCU temperature (in degrees C)
-#define HAL_TEMP() ( NAN )
+#define HAL_TEMP() ( tempmonGetTemp() )
 
 // Watchdog control macros --------------------------------------------------------------------------
 #if WATCHDOG != OFF

--- a/src/libApp/commands/ProcessCmds.cpp
+++ b/src/libApp/commands/ProcessCmds.cpp
@@ -133,7 +133,7 @@ CommandError CommandProcessor::command(char *reply, char *command, char *paramet
   //            Returns: +/-n.n
   if (command[0] == 'G' && command[1] == 'X' && parameter[0] == '9' && parameter[1] == 'F' && parameter[2] == 0) {
     float t = HAL_TEMP();
-    if (!isnan(t)) sprintF(reply, "%1.0f", t); else { *numericReply = true; commandError = CE_0; }
+    if (!isnan(t)) { sprintF(reply, "%1.0f", t); *numericReply = false; } else { *numericReply = true; commandError = CE_0; }
     return commandError;
   } else
 

--- a/src/observatory/Observatory.command.cpp
+++ b/src/observatory/Observatory.command.cpp
@@ -140,7 +140,6 @@ bool Observatory::command(char reply[], char command[], char parameter[], bool *
     #endif
       return false;
   } else
-    return false;
 
   return true;
 };


### PR DESCRIPTION
PJRC fixed the Teensy 4.1 internal temperature monitoring library in Teensyduino 5.0.
The tempmonGetTemp function just worked, but I found that (what I believe is) an extraneous return false; towards the end of Observatory.command.cpp prevented the handling for :SB & :GX9F in ProcessCmds.cpp ever being reached.
This time targeting master...