### PR TITLE
Humidity control

### DIFF
--- a/src/observatory/thermostat/Thermostat.command.cpp
+++ b/src/observatory/thermostat/Thermostat.command.cpp
@@ -120,7 +120,9 @@ bool Thermostat::command(char reply[], char command[], char parameter[], bool *s
     if (command[1] == 't' && parameter[0] == 0) {
       sprintf(reply, "%i,%i,%i", HEAT_RELAY, COOL_RELAY, HUMIDITY_RELAY);
       *numericReply = false;
-  } else 
+    } else 
+      return false;
+  } else
     return false;
 
   return true;

--- a/src/observatory/thermostat/Thermostat.command.cpp
+++ b/src/observatory/thermostat/Thermostat.command.cpp
@@ -113,6 +113,14 @@ bool Thermostat::command(char reply[], char command[], char parameter[], bool *s
     #endif
       return false;
   } else
+
+  if (command[0] == 'I') {
+    //  :It#  get Thermostat relay #defines
+    //         Returns: 8,9,-1#, HEAT_RELAY, COOL_RELAY, HUMIDITY_RELAY, -1 for undefined relay
+    if (command[1] == 't' && parameter[0] == 0) {
+      sprintf(reply, "%i,%i,%i", HEAT_RELAY, COOL_RELAY, HUMIDITY_RELAY);
+      *numericReply = false;
+  } else 
     return false;
 
   return true;

--- a/src/observatory/thermostat/Thermostat.cpp
+++ b/src/observatory/thermostat/Thermostat.cpp
@@ -12,7 +12,7 @@
 
 // by default heat/cool/humidity control are turned off when the roof is open
 // uncomment the line below to enable control with roof open
-#define ALLOW_COOL_WITH_ROOF_OPEN true
+//#define ALLOW_COOL_WITH_ROOF_OPEN true
 
 void thermostatWrapper() { thermostat.poll(); }
 

--- a/src/observatory/thermostat/Thermostat.cpp
+++ b/src/observatory/thermostat/Thermostat.cpp
@@ -8,6 +8,11 @@
 #include "../../lib/tasks/OnTask.h"
 #include "../../libApp/thermostatSensor/ThermostatSensor.h"
 #include "../../libApp/relay/Relay.h"
+#include "../roof/Roof.h"
+
+// by default heat/cool/humidity control are turned off when the roof is open
+// uncomment the line below to enable control with roof open
+//#define THERMO_CONTROL_WITH_ROOF_OPEN true
 
 void thermostatWrapper() { thermostat.poll(); }
 
@@ -29,7 +34,11 @@ void Thermostat::poll() {
   humidity = thermostatSensor.humidity();
 
   #if HEAT_RELAY != OFF
-    if (!isnan(averageTemperature) && averageTemperature < getHeatSetpoint() && getHeatSetpoint() != 0) {
+    if (!isnan(averageTemperature) && averageTemperature < getHeatSetpoint() && getHeatSetpoint() != 0
+      #ifndef THERMO_CONTROL_WITH_ROOF_OPEN
+        && roof.isClosed()
+      #endif
+    ) {
       relay.on(HEAT_RELAY);
     } else {
       relay.off(HEAT_RELAY);
@@ -37,7 +46,11 @@ void Thermostat::poll() {
   #endif
 
   #if COOL_RELAY != OFF
-    if (!isnan(averageTemperature) && averageTemperature > getCoolSetpoint() && getCoolSetpoint() != 0) {
+    if (!isnan(averageTemperature) && averageTemperature > getCoolSetpoint() && getCoolSetpoint() != 0
+      #ifndef THERMO_CONTROL_WITH_ROOF_OPEN
+        && roof.isClosed()
+      #endif
+    ) {
       relay.on(COOL_RELAY);
     } else {
       relay.off(COOL_RELAY);
@@ -45,7 +58,11 @@ void Thermostat::poll() {
   #endif
 
   #if HUMIDITY_RELAY != OFF
-    if (!isnan(humidity) && (humidity > getHumiditySetpoint()) && getHumiditySetpoint() != 0) {
+    if (!isnan(humidity) && (humidity > getHumiditySetpoint()) && getHumiditySetpoint() != 0
+      #ifndef THERMO_CONTROL_WITH_ROOF_OPEN
+        && roof.isClosed()
+      #endif
+    ) {
       relay.on(HUMIDITY_RELAY);
     } else if (!isnan(humidity) && (humidity < (getHumiditySetpoint() - 5))) {
       relay.off(HUMIDITY_RELAY);

--- a/src/observatory/thermostat/Thermostat.cpp
+++ b/src/observatory/thermostat/Thermostat.cpp
@@ -12,7 +12,7 @@
 
 // by default heat/cool/humidity control are turned off when the roof is open
 // uncomment the line below to enable control with roof open
-//#define THERMO_CONTROL_WITH_ROOF_OPEN true
+#define ALLOW_COOL_WITH_ROOF_OPEN true
 
 void thermostatWrapper() { thermostat.poll(); }
 
@@ -34,11 +34,7 @@ void Thermostat::poll() {
   humidity = thermostatSensor.humidity();
 
   #if HEAT_RELAY != OFF
-    if (!isnan(averageTemperature) && averageTemperature < getHeatSetpoint() && getHeatSetpoint() != 0
-      #ifndef THERMO_CONTROL_WITH_ROOF_OPEN
-        && roof.isClosed()
-      #endif
-    ) {
+    if (!isnan(averageTemperature) && averageTemperature < getHeatSetpoint() && getHeatSetpoint() != 0 && roof.isClosed()) {
       relay.on(HEAT_RELAY);
     } else {
       relay.off(HEAT_RELAY);
@@ -47,7 +43,7 @@ void Thermostat::poll() {
 
   #if COOL_RELAY != OFF
     if (!isnan(averageTemperature) && averageTemperature > getCoolSetpoint() && getCoolSetpoint() != 0
-      #ifndef THERMO_CONTROL_WITH_ROOF_OPEN
+      #ifndef ALLOW_COOL_WITH_ROOF_OPEN
         && roof.isClosed()
       #endif
     ) {
@@ -58,11 +54,7 @@ void Thermostat::poll() {
   #endif
 
   #if HUMIDITY_RELAY != OFF
-    if (!isnan(humidity) && (humidity > getHumiditySetpoint()) && getHumiditySetpoint() != 0
-      #ifndef THERMO_CONTROL_WITH_ROOF_OPEN
-        && roof.isClosed()
-      #endif
-    ) {
+    if (!isnan(humidity) && (humidity > getHumiditySetpoint()) && getHumiditySetpoint() != 0 && roof.isClosed()) {
       relay.on(HUMIDITY_RELAY);
     } else if (!isnan(humidity) && (humidity < (getHumiditySetpoint() - 5))) {
       relay.off(HUMIDITY_RELAY);


### PR DESCRIPTION
Two changes:
1. Adds command :It# to get thermostat relay defines in similar manner to how :IL# does for the Lights relay defines.
2. **Note: Default behaviour change.** Turns off Heat, Dehumidify, and optionally Cool/Vent relays when the roof is !Closed. The thinking is that it seems like a bad idea to leave these running when the roof is open as all the input heat/coolness/dryness will just be vented to the surrounded environment. The option for Cool/Vent is for situations when this is controlling Vent (as opposed to aircon) when it might be desired to keep air circulation. Option is a #define at the top of Thermostat.cpp as I don't believe it warrants an entry in Config.h