### PR TITLE
Set MODE_FORCED for BME/BMP280

### DIFF
--- a/src/libApp/thermostatSensor/TpBmp280.cpp
+++ b/src/libApp/thermostatSensor/TpBmp280.cpp
@@ -24,6 +24,8 @@ bool Bmp280t::init() {
   if (_inside_temperatureAssigned || _inside_pressureAssigned) return false;
 
   if (bmp280SensorT.begin(THERMOSTAT_SENSOR_TP_BMP280)) {
+    bme280SensorT.setSampling(Adafruit_BME280::MODE_FORCED, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::SAMPLING_X1,
+                              Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::FILTER_OFF);
     // follow any I2C device in-library init with a reset of the I2C bus speed
     #ifdef HAL_WIRE_RESET_AFTER_CONNECT
       Wire.end();

--- a/src/libApp/thermostatSensor/TphBme280.cpp
+++ b/src/libApp/thermostatSensor/TphBme280.cpp
@@ -27,6 +27,8 @@ bool Bme280t::init() {
   if (_inside_temperatureAssigned || _inside_pressureAssigned || _inside_humidityAssigned) return false;
 
   if (bme280SensorT.begin(THERMOSTAT_SENSOR_TPH_BME280)) {
+    bme280SensorT.setSampling(Adafruit_BME280::MODE_FORCED, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::SAMPLING_X1,
+                              Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::FILTER_OFF);
     // follow any I2C device in-library init with a reset of the I2C bus speed
     #ifdef HAL_WIRE_RESET_AFTER_CONNECT
       Wire.end();


### PR DESCRIPTION
I noticed that the Adafruit_BME280 library by default initialises the sensor to using 'high performance' settings that causes the sensor to sample and store results internally on a continual basis regardless of how often you poll for measurement - when you do you just get the last stored results from the registers. 

According to the device [datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bme280-ds002.pdf), in the example settings for weather monitoring (3.5.1 - Page 19) there are better settings for our slow changing use case. These reduce the device self heating which should make the temperature readings more accurate.

This change sets the mode to only take a reading when we poll and turns of the oversampling.