### PR TITLE
Bme p280 mode

### DIFF
--- a/src/libApp/thermostatSensor/TpBmp280.cpp
+++ b/src/libApp/thermostatSensor/TpBmp280.cpp
@@ -24,6 +24,8 @@ bool Bmp280t::init() {
   if (_inside_temperatureAssigned || _inside_pressureAssigned) return false;
 
   if (bmp280SensorT.begin(THERMOSTAT_SENSOR_TP_BMP280)) {
+    bme280SensorT.setSampling(Adafruit_BME280::MODE_FORCED, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::SAMPLING_X1,
+                              Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::FILTER_OFF);
     // follow any I2C device in-library init with a reset of the I2C bus speed
     #ifdef HAL_WIRE_RESET_AFTER_CONNECT
       Wire.end();

--- a/src/libApp/thermostatSensor/TpBmp280.cpp
+++ b/src/libApp/thermostatSensor/TpBmp280.cpp
@@ -48,10 +48,10 @@ bool Bmp280t::init() {
 // update
 void Bmp280t::poll() {
   if (!active) return;
-  bme280SensorT.takeForcedMeasurement();
   _inside_temperature = bmp280SensorT.readTemperature();
   tasks.yield(1000);
   _inside_pressure = bmp280SensorT.readPressure()/100.0;
+  bme280SensorT.takeForcedMeasurement();
 }
 
 Bmp280t bmp280t;

--- a/src/libApp/thermostatSensor/TpBmp280.cpp
+++ b/src/libApp/thermostatSensor/TpBmp280.cpp
@@ -48,7 +48,7 @@ bool Bmp280t::init() {
 // update
 void Bmp280t::poll() {
   if (!active) return;
-
+  bme280SensorT.takeForcedMeasurement();
   _inside_temperature = bmp280SensorT.readTemperature();
   tasks.yield(1000);
   _inside_pressure = bmp280SensorT.readPressure()/100.0;

--- a/src/libApp/thermostatSensor/TphBme280.cpp
+++ b/src/libApp/thermostatSensor/TphBme280.cpp
@@ -52,12 +52,12 @@ bool Bme280t::init() {
 // update
 void Bme280t::poll() {
   if (!active) return;
-  bme280SensorT.takeForcedMeasurement();
   _inside_temperature = bme280SensorT.readTemperature();
   tasks.yield(1000);
   _inside_pressure = bme280SensorT.readPressure()/100.0;
   tasks.yield(1000);
   _inside_humidity = bme280SensorT.readHumidity();
+  bme280SensorT.takeForcedMeasurement();
 }
 
 Bme280t bme280t;

--- a/src/libApp/thermostatSensor/TphBme280.cpp
+++ b/src/libApp/thermostatSensor/TphBme280.cpp
@@ -27,6 +27,8 @@ bool Bme280t::init() {
   if (_inside_temperatureAssigned || _inside_pressureAssigned || _inside_humidityAssigned) return false;
 
   if (bme280SensorT.begin(THERMOSTAT_SENSOR_TPH_BME280)) {
+    bme280SensorT.setSampling(Adafruit_BME280::MODE_FORCED, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::SAMPLING_X1,
+                              Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::FILTER_OFF);
     // follow any I2C device in-library init with a reset of the I2C bus speed
     #ifdef HAL_WIRE_RESET_AFTER_CONNECT
       Wire.end();

--- a/src/libApp/thermostatSensor/TphBme280.cpp
+++ b/src/libApp/thermostatSensor/TphBme280.cpp
@@ -52,6 +52,7 @@ bool Bme280t::init() {
 // update
 void Bme280t::poll() {
   if (!active) return;
+  bme280SensorT.takeForcedMeasurement();
   _inside_temperature = bme280SensorT.readTemperature();
   tasks.yield(1000);
   _inside_pressure = bme280SensorT.readPressure()/100.0;


### PR DESCRIPTION
Second attempt at this one. Now tested okay repeatedly.
Enables low power read-on-demand mode on BME280 that reduces self-heating and therefore makes the temperature measurement more accurate.
The takeForcedMeasurement is after the reads as in this mode the measurement takes longer as the device has to wake from sleep first. The reads therefore get the previous stored measurements. Init of forced mode seems to take a measurement as well.