### PR TITLE
Roof parks mount

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -191,6 +191,7 @@
 #define ROOF_AUTOCLOSE_DAWN           OFF //    OFF, ON displays option to automatically close roof at dawn.                  Option
 #define ROOF_AUTOCLOSE_DAWN_DEFAULT   OFF //    OFF, ON enables AUTOCLOSE_DAWN option at startup, disabled otherwise.         Option
 #define ROOF_AUTOCLOSE_SAFETY         OFF //    OFF, ON closes the roof automatically if an UNSAFE condition is detected.     Option
+#define ROOF_CLOSE_PARKS_MOUNT        OFF //    OFF, n. Where n=1..18 (Relay#) momentarily engages this relay to park mount.  Option
 
 #define ROOF_MOTOR_OPEN_RELAY         OFF //    OFF, n. Where n=1..18 (Relay#) engages this relay to open roof.               Option
 #define ROOF_MOTOR_CLOSE_RELAY        OFF //    OFF, n. Where n=1..18 (Relay#) engages this relay to close roof.              Option
@@ -209,6 +210,7 @@
 
 #define ROOF_TIME_AVG                 300 //    300, n. Where n=30..1200 (seconds) Average time to open or close roof.        Adjust
 #define ROOF_TIME_TOL                  30 //     30, n. Where n=0..120 (seconds) Additional time before stop & error thrown.  Adjust
+#define MOUNT_PARK_TIMEOUT             30 //     30, n. Where n=20..240 (seconds) Maximum time to park mount before error.    Adjust
 
 // DOME CONTROL PANEL --------------------------------------------------------------------------------------------------------------
 #define DOME                          OFF //    OFF, ON to enable the OCS website dome panel display.                         Option

--- a/Config.h
+++ b/Config.h
@@ -210,7 +210,7 @@
 
 #define ROOF_TIME_AVG                 300 //    300, n. Where n=30..1200 (seconds) Average time to open or close roof.        Adjust
 #define ROOF_TIME_TOL                  30 //     30, n. Where n=0..120 (seconds) Additional time before stop & error thrown.  Adjust
-#define MOUNT_PARK_TIMEOUT             30 //     30, n. Where n=20..240 (seconds) Maximum time to park mount before error.    Adjust
+#define MOUNT_PARK_TIMEOUT             30 //     30, n. Where n=20..480 (seconds) Maximum time to park mount before error.    Adjust
 
 // DOME CONTROL PANEL --------------------------------------------------------------------------------------------------------------
 #define DOME                          OFF //    OFF, ON to enable the OCS website dome panel display.                         Option

--- a/src/Validate.h
+++ b/src/Validate.h
@@ -403,8 +403,8 @@
   #error "Configuration (Config.h): ROOF_TIME_LIMIT_SENSE_FAIL must be a number between 1 and 60 (seconds.)"
 #endif
 
-#if MOUNT_PARK_TIMEOUT < 20 || MOUNT_PARK_TIMEOUT > 240
-  #error "Configuration (Config.h): MOUNT_PARK_TIMEOUT must be a number between 20 and 240 (seconds.)"
+#if MOUNT_PARK_TIMEOUT < 20 || MOUNT_PARK_TIMEOUT > 480
+  #error "Configuration (Config.h): MOUNT_PARK_TIMEOUT must be a number between 20 and 480 (seconds.)"
 #endif
 
 #if DOME == ON && AXIS1_DRIVER_MODEL == OFF

--- a/src/Validate.h
+++ b/src/Validate.h
@@ -319,7 +319,7 @@
   #error "Configuration (Config.h): ROOF_CLOSE_PARKS_MOUNT must OFF or a number between 1 and 18 (RELAY#.)"
 #endif
 
-#if (ROOF_CLOSE_PARKS_MOUNT < 1 || ROOF_CLOSE_PARKS_MOUNT > 18) && ROOF_INTERLOCK_SENSE == OFF
+#if (ROOF_CLOSE_PARKS_MOUNT > 0 && ROOF_CLOSE_PARKS_MOUNT < 19) && ROOF_INTERLOCK_SENSE == OFF
   #error "Configuration (Config.h): ROOF_INTERLOCK_SENSE must be a number between 1 and 8 (SENSE#) if ROOF_CLOSE_PARKS_MOUNT is used."
 #endif
 

--- a/src/Validate.h
+++ b/src/Validate.h
@@ -315,6 +315,14 @@
   #error "Configuration (Config.h): ROOF_AUTOCLOSE_SAFETY, OCS website ROOF automatic close safety, must OFF or ON."
 #endif
 
+#if (ROOF_CLOSE_PARKS_MOUNT < 1 || ROOF_CLOSE_PARKS_MOUNT > 18) && ROOF_CLOSE_PARKS_MOUNT != OFF
+  #error "Configuration (Config.h): ROOF_CLOSE_PARKS_MOUNT must OFF or a number between 1 and 18 (RELAY#.)"
+#endif
+
+#if (ROOF_CLOSE_PARKS_MOUNT < 1 || ROOF_CLOSE_PARKS_MOUNT > 18) && ROOF_INTERLOCK_SENSE == OFF
+  #error "Configuration (Config.h): ROOF_INTERLOCK_SENSE must be a number between 1 and 8 (SENSE#) if ROOF_CLOSE_PARKS_MOUNT is used."
+#endif
+
 #if (ROOF_MOTOR_OPEN_RELAY < 1 || ROOF_MOTOR_OPEN_RELAY > 18) && ROOF_MOTOR_OPEN_RELAY != OFF
   #error "Configuration (Config.h): ROOF_MOTOR_OPEN_RELAY must OFF or a number between 1 and 18 (RELAY#.)"
 #endif
@@ -393,6 +401,10 @@
 
 #if ROOF_TIME_LIMIT_SENSE_FAIL < 1 || ROOF_TIME_LIMIT_SENSE_FAIL > 60
   #error "Configuration (Config.h): ROOF_TIME_LIMIT_SENSE_FAIL must be a number between 1 and 60 (seconds.)"
+#endif
+
+#if MOUNT_PARK_TIMEOUT < 20 || MOUNT_PARK_TIMEOUT > 240
+  #error "Configuration (Config.h): MOUNT_PARK_TIMEOUT must be a number between 20 and 240 (seconds.)"
 #endif
 
 #if DOME == ON && AXIS1_DRIVER_MODEL == OFF

--- a/src/lib/gpio/TCA9555.cpp
+++ b/src/lib/gpio/TCA9555.cpp
@@ -1,8 +1,6 @@
 // -----------------------------------------------------------------------------------
 // I2C TCA9555 GPIO support
 
-#include "Tca9555.h"
-
 #if defined(GPIO_DEVICE) && GPIO_DEVICE == X9555
 
 #ifndef GPIO_TCA9555_I2C_ADDRESS

--- a/src/observatory/roof/Roof.cpp
+++ b/src/observatory/roof/Roof.cpp
@@ -103,6 +103,12 @@ void parkedPoll() {
 
 // Start closing the roof, returns true if successful or false otherwise (required)
 bool Roof::close() {
+  // Check to see if the roof is already closed
+  if (sense.isOn(ROOF_LIMIT_CLOSED_SENSE) && !sense.isOn(ROOF_LIMIT_OPENED_SENSE)) {
+    lastError = RERR_CLOSE_EXCEPT_CLOSED;
+    return false;
+  }
+
   // If mount must be parked for roof to close, issue a park signal and start park timer
   if (!safetyOverride && ROOF_CLOSE_PARKS_MOUNT != OFF && !sense.isOn(ROOF_INTERLOCK_SENSE) && waitingForPark == 0) {
     VF("MSG: Start park monitor task (rate 1000ms priority 7)... ");
@@ -146,13 +152,7 @@ bool Roof::close() {
     return false;
   }
 
-  // Check to see if the roof is already closed
-  if (sense.isOn(ROOF_LIMIT_CLOSED_SENSE) && !sense.isOn(ROOF_LIMIT_OPENED_SENSE)) {
-    lastError = RERR_CLOSE_EXCEPT_CLOSED;
-    return false;
-  }
-
-  // Just one last sanity check before we start moving the roof
+    // Just one last sanity check before we start moving the roof
   if (sense.isOn(ROOF_LIMIT_CLOSED_SENSE) && sense.isOn(ROOF_LIMIT_OPENED_SENSE)) {
     lastError = RERR_CLOSE_EXCEPT_OPENED_LIMIT_SW_ON;
     return false;

--- a/src/observatory/roof/Roof.cpp
+++ b/src/observatory/roof/Roof.cpp
@@ -94,12 +94,19 @@ bool Roof::open() {
   return true;
 }
 
+// Check if the mount is parked
+void parkedPoll() {
+  if (roof.checkMountParked()) {
+    roof.close();
+  }
+}
+
 // Start closing the roof, returns true if successful or false otherwise (required)
 bool Roof::close() {
   // If mount must be parked for roof to close, issue a park signal and park timer
   if (ROOF_CLOSE_PARKS_MOUNT != OFF && !sense.isOn(ROOF_INTERLOCK_SENSE) && waitingForPark == 0) {
     VF("MSG: Start park monitor task (rate 1000ms priority 7)... ");
-    if (tasks.add(1000, 0, true, 7, parkedPoll, "pkPoll")) { VLF("success"); active = true; } else { VLF("FAILED!"); }
+    if (tasks.add(1000, 0, true, 7, parkedPoll, "pkPoll")) { VLF("success"); } else { VLF("FAILED!"); }
     relay.onDelayedOff(ROOF_CLOSE_PARKS_MOUNT, 1.0);
     return true;
   }
@@ -478,13 +485,7 @@ void Roof::continueClosing() {
   }
 }
 
-// Check if the mount is parked
-void parkedPoll() {
-  if (roof.checkMountParked()) {
-    roof.close();
-  }
-}
-
+// Check if the mount is parked, 
 bool Roof::checkMountParked() {
   if (sense.isOn(ROOF_INTERLOCK_SENSE)) {
     tasks.setDurationComplete(tasks.getHandleByName("pkPoll"));

--- a/src/observatory/roof/Roof.cpp
+++ b/src/observatory/roof/Roof.cpp
@@ -73,7 +73,7 @@ bool Roof::open() {
   clearStatus(false);
 
   delay(ROOF_TIME_PRE_MOTION*1000);
-  if (ROOF_INTERLOCK_SENSE != OFF && !sense.isOn(ROOF_INTERLOCK_SENSE)) {
+  if (!safetyOverride && ROOF_INTERLOCK_SENSE != OFF && !sense.isOn(ROOF_INTERLOCK_SENSE)) {
     state = 'i';
     lastError = RERR_OPEN_SAFETY_INTERLOCK;
     return false;
@@ -103,7 +103,7 @@ void parkedPoll() {
 
 // Start closing the roof, returns true if successful or false otherwise (required)
 bool Roof::close() {
-  // If mount must be parked for roof to close, issue a park signal and park timer
+  // If mount must be parked for roof to close, issue a park signal and start park timer
   if (!safetyOverride && ROOF_CLOSE_PARKS_MOUNT != OFF && !sense.isOn(ROOF_INTERLOCK_SENSE) && waitingForPark == 0) {
     VF("MSG: Start park monitor task (rate 1000ms priority 7)... ");
     if (tasks.add(1000, 0, true, 7, parkedPoll, "pkPoll")) { VLF("success"); waitingForPark ++;} else { VLF("FAILED!"); }
@@ -169,7 +169,7 @@ bool Roof::close() {
   clearStatus(false);
 
   delay(ROOF_TIME_PRE_MOTION*1000);
-  if (ROOF_INTERLOCK_SENSE != OFF && !sense.isOn(ROOF_INTERLOCK_SENSE)) {
+  if (!safetyOverride && ROOF_INTERLOCK_SENSE != OFF && !sense.isOn(ROOF_INTERLOCK_SENSE)) {
     state = 'i';
     lastError = RERR_CLOSE_SAFETY_INTERLOCK;
     return false;

--- a/src/observatory/roof/Roof.h
+++ b/src/observatory/roof/Roof.h
@@ -108,6 +108,9 @@ class Roof {
 
     // called repeatedly to check if mount is parked
     bool checkMountParked();
+    
+    // counter for waiting period
+    int waitingForPark = 0;
 
   private:
     // called repeatedly to open the roof
@@ -120,8 +123,7 @@ class Roof {
     volatile char state = 'i';
     RoofFault fault = {false, false, false, false, false, false, false, false, false, false, false};
     RoofError lastError = RERR_NONE;
-    int waitingForPark = 0;
-
+    
     // roof power and safety
     volatile bool safetyOverride = false;
     volatile bool maxPower = false;

--- a/src/observatory/roof/Roof.h
+++ b/src/observatory/roof/Roof.h
@@ -118,7 +118,7 @@ class Roof {
 
     // roof status and errors
     volatile char state = 'i';
-    RoofFault fault = {false, false, false, false, false, false, false, false, false, false};
+    RoofFault fault = {false, false, false, false, false, false, false, false, false, false, false};
     RoofError lastError = RERR_NONE;
     int waitingForPark = 0;
 
@@ -155,7 +155,7 @@ class Roof {
       "Error: Opened/closed limit sw on",    // 17
       "Warning: Already open",               // 18
       "Error: Open location unknown",        // 19
-      "Error: Open already in motion"        // 20
+      "Error: Open already in motion",       // 20
       "Error: Close mount not parked"        // 21
     };
 };

--- a/src/observatory/roof/Roof.h
+++ b/src/observatory/roof/Roof.h
@@ -106,15 +106,15 @@ class Roof {
     // for soft start etc, pwm power level (required)
     int powerLevel();
 
+    // called repeatedly to check if mount is parked
+    bool checkMountParked();
+
   private:
     // called repeatedly to open the roof
     void continueOpening();
 
     // called repeatedly to close the roof
     void continueClosing();
-
-    // called repeatedly to check if mount is parked
-    bool checkMountParked();
 
     // roof status and errors
     volatile char state = 'i';

--- a/src/observatory/roof/Roof.h
+++ b/src/observatory/roof/Roof.h
@@ -27,7 +27,8 @@ typedef enum RoofError {
   RERR_OPEN_EXCEPT_CLOSED_LIMIT_SW_ON,
   RERR_OPEN_EXCEPT_OPENED,
   RERR_OPEN_LOCATION_UNKNOWN,
-  RERR_OPEN_EXCEPT_IN_MOTION
+  RERR_OPEN_EXCEPT_IN_MOTION,
+  RERR_CLOSE_EXCEPT_MOUNT_NOT_PARKED
 } RoofError;
 
 #include "../../libApp/commands/ProcessCmds.h"
@@ -43,6 +44,7 @@ typedef struct RoofFault {
   uint16_t closeLimitSW: 1;
   uint16_t closeOverTime: 1;
   uint16_t closeUnderTime: 1;
+  uint16_t closeNotParked: 1;
 } RoofFault;
 
 class Roof {
@@ -111,10 +113,14 @@ class Roof {
     // called repeatedly to close the roof
     void continueClosing();
 
+    // called repeatedly to check if mount is parked
+    bool checkMountParked();
+
     // roof status and errors
     volatile char state = 'i';
     RoofFault fault = {false, false, false, false, false, false, false, false, false, false};
     RoofError lastError = RERR_NONE;
+    int waitingForPark = 0;
 
     // roof power and safety
     volatile bool safetyOverride = false;
@@ -128,7 +134,7 @@ class Roof {
     long travel = 0;
     unsigned long openStartTime, closeStartTime;
 
-    const char * ErrorMessage[21] = {
+    const char * ErrorMessage[22] = {
       "",                                    // 0
       "Error: Open safety interlock",        // 1
       "Error: Close safety interlock",       // 2
@@ -150,6 +156,7 @@ class Roof {
       "Warning: Already open",               // 18
       "Error: Open location unknown",        // 19
       "Error: Open already in motion"        // 20
+      "Error: Close mount not parked"        // 21
     };
 };
 

--- a/src/pages/RoofTile.cpp
+++ b/src/pages/RoofTile.cpp
@@ -44,7 +44,7 @@
     if (roof.isClosing()) strcpy(ws1, "Closing");
 
     const char *statusStr = roof.getStatus();
-    if (strstr(statusStr, "No Error") || strstr(statusStr, "Travel: ") || strstr(statusStr, "Waiting for mount to park") 
+    if (strstr(statusStr, "No Error") || strstr(statusStr, "Travel: ") || strstr(statusStr, "Waiting for mount to park")) 
       strcpy(ws2, "#505090");
     else 
       strcpy(ws2, "red");

--- a/src/pages/RoofTile.cpp
+++ b/src/pages/RoofTile.cpp
@@ -44,7 +44,7 @@
     if (roof.isClosing()) strcpy(ws1, "Closing");
 
     const char *statusStr = roof.getStatus();
-    if (strstr(statusStr, "No Error") || strstr(statusStr, "Travel: ")) 
+    if (strstr(statusStr, "No Error") || strstr(statusStr, "Travel: ") || strstr(statusStr, "Waiting for mount to park") 
       strcpy(ws2, "#505090");
     else 
       strcpy(ws2, "red");


### PR DESCRIPTION
PR to address issue #17.
Added ROOF_CLOSE_PARKS_MOUNT.
Added MOUNT_PARK_TIMEOUT as 30 - 240 seconds. Allows for mount with 1°/sec slew plus a minute for ramp up/down/tolerance.
Added validation for new options.
Added parked polling task and function as suggested.
Changed the stop function to additional cancel a close waiting for mount park.
Moved already closed check to top of close function.
Added safety override option into interlock checks on both open and close functions. Existing comments suggest these should have already had this and it makes sense to me.
Added new roof error and status.

Unrelated - removed the additional lower case #include "Tca9555.h"

I made the momentary relay close to signal the mount to park a 2 second duration. I'm assuming this is long enough for OnStep to definitely poll for the signal on any supported MCU but though I'd mention it just in case.