### PR TITLE
Extend dome status return codes. Fix digits in :IN#

### DIFF
--- a/src/observatory/Observatory.command.cpp
+++ b/src/observatory/Observatory.command.cpp
@@ -86,7 +86,7 @@ bool Observatory::command(char reply[], char command[], char parameter[], bool *
     //  :IN#  get version Number
     //         Returns: s#
     if (command[1] == 'N' && parameter[0] == 0) {
-      sprintf(reply, "%i.%i%s", (int)firmware.version.major, (int)firmware.version.minor, firmware.version.patch);
+      sprintf(reply, "%d.%02d%s", (int)firmware.version.major, (int)firmware.version.minor, firmware.version.patch);
       *numericReply = false;
     } else
 

--- a/src/observatory/dome/Dome.command.cpp
+++ b/src/observatory/dome/Dome.command.cpp
@@ -124,7 +124,7 @@ bool Dome::command(char reply[], char command[], char parameter[], bool *supress
     } else
 
     //  :DU#  Get Dome Status
-    //         Returns: 'P' if parked, 'S' if slewing, 'H' if at Home, 'I' if idle/stopped
+    //         Returns: 'P' if parked, 'K' if parking, 'S' if slewing, 'H' if at Home, 'I' if idle
     if (command[1] == 'U' && parameter[0] == 0) {
       if (dome.isParked()) reply[0] = 'P'; else
       if (settings.park.state == PS_PARKING) reply[0] = 'K'; else

--- a/src/observatory/dome/Dome.command.cpp
+++ b/src/observatory/dome/Dome.command.cpp
@@ -124,15 +124,17 @@ bool Dome::command(char reply[], char command[], char parameter[], bool *supress
     } else
 
     //  :DU#  Get Dome Status
-    //         Returns: 'P' if parked, 'H' if at Home
+    //         Returns: 'P' if parked, 'S' if slewing, 'H' if at Home, 'I' if idle/stopped
     if (command[1] == 'U' && parameter[0] == 0) {
       if (dome.isParked()) reply[0] = 'P'; else
+      if (settings.park.state == PS_PARKING) reply[0] = 'K'; else
+      if (dome.isSlewing()) reply[0] = 'S'; else
       #if AXIS2_DRIVER_MODEL != OFF
         if (dome.getAzimuth() == 0.0F && dome.getAltitude() == 0.0F) reply[0] = 'H'; else
       #else
         if (dome.getAzimuth() == 0.0F) reply[0] = 'H'; else
       #endif
-      reply[0] = 0;
+      reply[0] = 'I';
       reply[1] = 0;
       *numericReply = false;
     } else *commandError = CE_CMD_UNKNOWN;

--- a/src/observatory/dome/Dome.cpp
+++ b/src/observatory/dome/Dome.cpp
@@ -111,10 +111,10 @@ CommandError Dome::syncAzimuthTarget() {
   #if defined(ROOF_PRESENT) && DOME_SHUTTER_LOCK == ON
     if (!roof.open()) return CE_SLEW_ERR_IN_STANDBY;
   #endif
-  if (settings.park.state >= PS_PARKED) return CE_PARKED;
+  if (settings.park.state >= PS_PARKED) return CE_SLEW_ERR_IN_PARK;
 
   VF("MSG: Dome, sync azimuth target coordinate set ("); V(targetAzm); VL("°)");
-
+  reset();
   axis1.enable(true);
   axis1.setInstrumentCoordinate(targetAzm);
 

--- a/src/observatory/dome/Dome.cpp
+++ b/src/observatory/dome/Dome.cpp
@@ -91,7 +91,7 @@ CommandError Dome::gotoAzimuthTarget() {
   #if defined(ROOF_PRESENT) && DOME_SHUTTER_LOCK == ON
     if (!roof.open()) return CE_SLEW_ERR_IN_STANDBY;
   #endif
-  if (settings.park.state >= PS_PARKED) return CE_PARKED;
+  if (settings.park.state >= PS_PARKED) return CE_SLEW_ERR_IN_PARK;
 
   VF("MSG: Dome, goto azimuth target coordinate set ("); V(targetAzm); VL("°)");
   VLF("MSG: Dome, starting goto");
@@ -127,7 +127,7 @@ CommandError Dome::gotoAltitudeTarget() {
     #if defined(ROOF_PRESENT) && DOME_SHUTTER_LOCK == ON
       if (!roof.open()) return CE_SLEW_ERR_IN_STANDBY;
     #endif
-    if (settings.park.state >= PS_PARKED) return CE_PARKED;
+    if (settings.park.state >= PS_PARKED) return CE_SLEW_ERR_IN_PARK;
 
     VF("MSG: Dome, goto altitude target coordinate set ("); V(targetAlt); VL("°)");
     VLF("MSG: Dome, starting goto");

--- a/src/pages/Index.cpp
+++ b/src/pages/Index.cpp
@@ -152,10 +152,7 @@ void indexAjax() {
       #endif
     }
     if (press.equals("dome_sync")) {
-      dome.gotoAzimuthTarget();
-      #if AXIS2_DRIVER_MODEL != OFF
-        dome.gotoAltitudeTarget();
-      #endif
+      dome.syncAzimuthTarget();
     }
     if (press.equals("dome_stop")) dome.stop();
     if (press.equals("dome_home")) dome.findHome();


### PR DESCRIPTION
Extend :DU# to give additional return codes to provide the same information as the Dome page.
Fix :IN# to return two digits for the minor version number.