### PR TITLE
Use ForcedMeasurement mode for BME280 weather

### DIFF
--- a/src/libApp/weatherSensor/TphBme280.cpp
+++ b/src/libApp/weatherSensor/TphBme280.cpp
@@ -30,6 +30,8 @@ bool Bme280w::init() {
   if (_temperatureAssigned || _pressureAssigned || _humidityAssigned) return false;
 
   if (bme280SensorW.begin(WEATHER_SENSOR_TPH_BME280)) {
+    bme280SensorW.setSampling(Adafruit_BME280::MODE_FORCED, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::SAMPLING_X1,
+                              Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::FILTER_OFF);
     // follow any I2C device in-library init with a reset of the I2C bus speed
     #ifdef HAL_WIRE_RESET_AFTER_CONNECT
       Wire.end();
@@ -68,6 +70,7 @@ void Bme280w::poll() {
   _pressure = bme280SensorW.readPressure()/100.0;
   tasks.yield(1000);
   _humidity = bme280SensorW.readHumidity();
+  bme280SensorW.takeForcedMeasurement();
 }
 
 Bme280w bme280w;


### PR DESCRIPTION
Just started testing my weather station and noticed a difference between reading on two BME280's side-by-side on the desk. When I checked it turns out that I hadn't noticed that there's separate classes for the BME when used for Thermostat and Weather monitoring.

This PR updates the weather BME usages to be the same as the thermostat class as per PR #16.
The readings now agree with 1/2 deg C & 2% Rh between sensors (before this change the difference error were more than double that).