### PR TITLE
Wind cup anem

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -146,8 +146,10 @@
 #define WEATHER_SENSOR_T_ANALOG2DEGC(x) (((x*3.3)-0.1)*100.0-40.0)
 
 #define WEATHER_SENSOR_WIND_CUP       OFF //    OFF, n. Where n=1..8 (Sense#) to enable. Wind speed, cup anemometer.          Option
-// Conversion factor, pulses per minute (x) to wind speed in KPH
+// Conversion factor, pulses per minute (x) to wind speed in KPH                                                Adjust
 #define WEATHER_SENSOR_WIND_CUP2KPH(x) (x*0.087)
+#define WEATHER_SENSOR_WIND_EDGE  FALLING //     RISING or FALLING. Pulse edge to detect.                                     Adjust
+#define WEATHER_SENSOR_WIND_CUP_DB    OFF //    OFF, n. Where n=1..100 (ms) Wind Cup input debounce time.                     Option
 
 #define WEATHER_SENSOR_WIND_REV_P     OFF //    OFF, n. Where n=1..16 (Analog#) to enable. Wind speed.                        Option
 

--- a/Config.h
+++ b/Config.h
@@ -146,7 +146,7 @@
 #define WEATHER_SENSOR_T_ANALOG2DEGC(x) (((x*3.3)-0.1)*100.0-40.0)
 
 #define WEATHER_SENSOR_WIND_CUP       OFF //    OFF, n. Where n=1..8 (Sense#) to enable. Wind speed, cup anemometer.          Option
-// Conversion factor, pulses per minute (x) to wind speed in KPH                                                Adjust
+// Conversion factor, pulses per minute (x) to wind speed in KPH                                                              Adjust
 #define WEATHER_SENSOR_WIND_CUP2KPH(x) (x*0.087)
 #define WEATHER_SENSOR_WIND_EDGE  FALLING //     RISING or FALLING. Pulse edge to detect.                                     Adjust
 #define WEATHER_SENSOR_WIND_CUP_DB    OFF //    OFF, n. Where n=1..100 (ms) Wind Cup input debounce time.                     Option

--- a/Config.h
+++ b/Config.h
@@ -148,7 +148,7 @@
 #define WEATHER_SENSOR_WIND_CUP       OFF //    OFF, n. Where n=1..8 (Sense#) to enable. Wind speed, cup anemometer.          Option
 // Conversion factor, pulses per minute (x) to wind speed in KPH                                                              Adjust
 #define WEATHER_SENSOR_WIND_CUP2KPH(x) (x*0.087)
-#define WEATHER_SENSOR_WIND_EDGE  FALLING //     RISING or FALLING. Pulse edge to detect.                                     Adjust
+#define WEATHER_SENSOR_WIND_EDGE  FALLING //    RISING or FALLING. Pulse edge to detect.                                      Adjust
 #define WEATHER_SENSOR_WIND_CUP_DB    OFF //    OFF, n. Where n=1..100 (ms) Wind Cup input debounce time.                     Option
 
 #define WEATHER_SENSOR_WIND_REV_P     OFF //    OFF, n. Where n=1..16 (Analog#) to enable. Wind speed.                        Option

--- a/src/Validate.h
+++ b/src/Validate.h
@@ -131,6 +131,18 @@
   #error "Configuration (Config.h): WEATHER_WIND_SPD_THRESHOLD must be a number between 0 and 100 (kph.)"
 #endif
 
+#if WEATHER_SENSOR_WIND_CUP != OFF && (WEATHER_SENSOR_WIND_CUP<1 || WEATHER_SENSOR_WIND_CUP>8)
+  #error "Configuration (Config.h): WEATHER_SENSOR_WIND_CUP must OFF or a number between 1 and 8 (SENSE#.)"
+#endif
+
+#if WEATHER_SENSOR_WIND_CUP != OFF && WEATHER_SENSOR_WIND_EDGE != FALLING && WEATHER_SENSOR_WIND_EDGE != RISING
+  #error "Configuration (Config.h): WEATHER_SENSOR_WIND_EDGE must RISING or FALLING"
+#endif
+
+#if WEATHER_SENSOR_WIND_CUP_DB != OFF && (WEATHER_SENSOR_WIND_CUP_DB<1 || WEATHER_SENSOR_WIND_CUP_DB>100)
+  #error "Configuration (Config.h): WEATHER_SENSOR_WIND_CUP_DB must OFF or a number between 1 and 100 (ms.)"
+#endif
+
 #if WEATHER_SKY_QUAL != OFF && WEATHER_SKY_QUAL != ON
   #error "Configuration (Config.h): WEATHER_SKY_QUAL, OCS temperature input, must OFF or ON."
 #endif


### PR DESCRIPTION
I've made a wind cup Anemometer that uses a reed switch. This is quite bouncy and on contact close results in a falling edge. Using the rising edge initially triggers on the first contact bounce so slow moving events could fall outside of a reasonable debounce period resulting in a double count.

This PR adds options for choice of RISING or FALLING edge trigger and a debounce time that can be applied to the wind cup Anemometer.