### PR TITLE
Finish BMP280 mode changes + fix typos.

### DIFF
--- a/src/libApp/thermostatSensor/ThermostatSensor.cpp
+++ b/src/libApp/thermostatSensor/ThermostatSensor.cpp
@@ -33,7 +33,7 @@ void ThermostatSensor::init(){
     bmp280t.init();
   #endif
 
-  #if defined(THERMOSTAT_SENSOR_TP_BMP280) && THERMOSTAT_SENSOR_TP_BMP280 != OFF
+  #if defined(THERMOSTAT_SENSOR_TP_BMP085) && THERMOSTAT_SENSOR_TP_BMP085 != OFF
     bmp085t.init();
   #endif
 

--- a/src/libApp/thermostatSensor/TpBmp280.cpp
+++ b/src/libApp/thermostatSensor/TpBmp280.cpp
@@ -24,8 +24,8 @@ bool Bmp280t::init() {
   if (_inside_temperatureAssigned || _inside_pressureAssigned) return false;
 
   if (bmp280SensorT.begin(THERMOSTAT_SENSOR_TP_BMP280)) {
-    bme280SensorT.setSampling(Adafruit_BME280::MODE_FORCED, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::SAMPLING_X1,
-                              Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::FILTER_OFF);
+    bmp280SensorT.setSampling(Adafruit_BMP280::MODE_FORCED, Adafruit_BMP280::SAMPLING_X1,
+                              Adafruit_BMP280::SAMPLING_X1, Adafruit_BMP280::FILTER_OFF);
     // follow any I2C device in-library init with a reset of the I2C bus speed
     #ifdef HAL_WIRE_RESET_AFTER_CONNECT
       Wire.end();
@@ -51,7 +51,7 @@ void Bmp280t::poll() {
   _inside_temperature = bmp280SensorT.readTemperature();
   tasks.yield(1000);
   _inside_pressure = bmp280SensorT.readPressure()/100.0;
-  bme280SensorT.takeForcedMeasurement();
+  bmp280SensorT.takeForcedMeasurement();
 }
 
 Bmp280t bmp280t;

--- a/src/libApp/weatherSensor/TpBmp280.cpp
+++ b/src/libApp/weatherSensor/TpBmp280.cpp
@@ -26,6 +26,8 @@ bool Bmp280w::init() {
   if (_temperatureAssigned || _pressureAssigned) return false;
 
   if (bmp280SensorW.begin(WEATHER_SENSOR_TP_BMP280)) {
+    bmp280SensorW.setSampling(Adafruit_BMP280::MODE_FORCED, Adafruit_BMP280::SAMPLING_X1,
+                              Adafruit_BMP280::SAMPLING_X1, Adafruit_BMP280::FILTER_OFF);
     // follow any I2C device in-library init with a reset of the I2C bus speed
     #ifdef HAL_WIRE_RESET_AFTER_CONNECT
       Wire.end();
@@ -41,7 +43,7 @@ bool Bmp280w::init() {
         strcpy(_temperatureName, "Bosch BMP280 Temperature Sensor on I2C");
       }
       if (!_pressureAssigned) {
-        _humidityAss_pressureAssignedigned = true;
+        _pressureAssigned = true;
         strcpy(_pressureName, "Bosch BMP280 Pressure Sensor on I2C");
       }
       active = true;
@@ -58,6 +60,8 @@ void Bmp280w::poll() {
   _temperature = bmp280SensorW.readTemperature();
   tasks.yield(1000);
   _pressure = bmp280SensorW.readPressure()/100.0;
+  bmp280SensorW.takeForcedMeasurement();
+
 }
 
 Bmp280w bmp280w;


### PR DESCRIPTION
Completes the change of BMP280 measurement mode. I'd missed some bit as I'd forgotten about the near duplication between weatherSensor/ and thermostatSensor/ classes, and I'd left some copy 'n' paste errors in there.
Also found a copy 'n' paste error in ThermostatSensor.cpp
Not tested on BMP280 hardware but is verified that it compiles against the Adafruit library.