### PR TITLE
delete WEATHER_SENSOR_RAIN_XY from RainGeneric.h

### DIFF
--- a/src/libApp/weatherSensor/RainGeneric.h
+++ b/src/libApp/weatherSensor/RainGeneric.h
@@ -8,10 +8,7 @@
 
 #if defined(WEATHER_SENSOR_RAIN_GENERIC) && WEATHER_SENSOR_RAIN_GENERIC != OFF
 
-#define WEATHER_SENSOR_RAIN_LOW 0.25
-#define WEATHER_SENSOR_RAIN_HIGH 0.75
-
-// setup anemometer
+// setup Rain Sensor
 class RainGeneric {
   public:
     bool init();


### PR DESCRIPTION
If the constants "WEATHER_SENSOR_RAIN_LOW" and "WEATHER_SENSOR_RAIN_HIGH" are defined in the file "RainGeneric.h", the values from the file "Config.h" are overwritten.