### PR TITLE
Adds STAT_MAINS_SAFETY_DELAY option + fix STAT panel.

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -44,6 +44,7 @@
 #define STAT_MAINS_SENSE              OFF //    OFF, n. Where n=1..8 (Sense#) mains power good, OFF (power failure) is UNSAFE Option
 #define STAT_MAINS_CURRENT_ANALOG     OFF //    OFF, n. Where n=1..16 (Analog#) measure/display current mains.                Option
 #define STAT_MAINS_AUX_CURRENT_ANALOG OFF //    OFF, n. Where n=1..16 (Analog#) measure/display current mains (aux.)          Option
+#define STAT_MAINS_SAFETY_DELAY       OFF //    OFF, n. Where n=1..600 (s). Mains safety sense delay time.                    Option
 
 // Converts the analog measure (range 0 to 1.0) to Amps
 #define STAT_MAINS_ANALOG_TO_CURRENT(x) (x*NAN)

--- a/src/Validate.h
+++ b/src/Validate.h
@@ -62,6 +62,10 @@
   #error "Configuration (Config.h): STAT_MAINS_AUX_CURRENT_ANALOG must OFF or between 1 and 16 (ASENSE#.)"
 #endif
 
+#if (STAT_MAINS_SAFETY_DELAY < 1 || STAT_MAINS_SAFETY_DELAY > 600) && STAT_MAINS_SAFETY_DELAY != OFF
+  #error "Configuration (Config.h): STAT_MAINS_SAFETY_DELAY must OFF or between 1 and 600 (s.)"
+#endif
+
 #if (STAT_DC_VOLTAGE_ANALOG < 1 || STAT_DC_VOLTAGE_ANALOG > 16) && STAT_DC_VOLTAGE_ANALOG != OFF
   #error "Configuration (Config.h): STAT_DC_VOLTAGE_ANALOG must OFF or between 1 and 16 (ASENSE#.)"
 #endif

--- a/src/observatory/safety/Safety.cpp
+++ b/src/observatory/safety/Safety.cpp
@@ -26,7 +26,15 @@ bool Safety::isSafe() {
 
   #if STAT_MAINS_SENSE != OFF
     // check for mains power out
-    if (!sense.isOn(STAT_MAINS_SENSE)) safe = false;
+    #if (STAT_MAINS_SAFETY_DELAY != OFF )
+      if (delayForMains >= STAT_MAINS_SAFETY_DELAY && !sense.isOn(STAT_MAINS_SENSE)) safe = false;
+      else {
+        if (!sense.isOn(STAT_MAINS_SENSE)) delayForMains ++;
+         else delayForMains = 0;
+      }
+    #else
+      if (!sense.isOn(STAT_MAINS_SENSE)) safe = false;
+    #endif
   #endif
 
   #ifdef WEATHER_PRESENT

--- a/src/observatory/safety/Safety.cpp
+++ b/src/observatory/safety/Safety.cpp
@@ -26,15 +26,11 @@ bool Safety::isSafe() {
 
   #if STAT_MAINS_SENSE != OFF
     // check for mains power out
-    #if (STAT_MAINS_SAFETY_DELAY != OFF )
-      if (delayForMains >= STAT_MAINS_SAFETY_DELAY && !sense.isOn(STAT_MAINS_SENSE)) safe = false;
-      else {
-        if (!sense.isOn(STAT_MAINS_SENSE)) delayForMains ++;
-         else delayForMains = 0;
-      }
-    #else
-      if (!sense.isOn(STAT_MAINS_SENSE)) safe = false;
-    #endif
+    if (sense.isOn(STAT_MAINS_SENSE)) {
+      delayForMains = 0;
+    } else {
+      if (delayForMains < STAT_MAINS_SAFETY_DELAY) delayForMains++; else safe = false;
+    }
   #endif
 
   #ifdef WEATHER_PRESENT

--- a/src/observatory/safety/Safety.h
+++ b/src/observatory/safety/Safety.h
@@ -16,6 +16,7 @@ class Safety {
 
   private:
     bool roofAutoCloseInitiated = false;
+    int delayForMains = 0; // counter for delay period
 };
 
 extern Safety safety;

--- a/src/pages/index/StatusTile.cpp
+++ b/src/pages/index/StatusTile.cpp
@@ -44,6 +44,7 @@
     www.sendContent(temp);
 
     #if STAT_MAINS_SENSE != OFF
+      getStatusMainsSenseStr(temp1);
       sprintf_P(temp, htmlInnerStatusMains, temp1);
       www.sendContent(temp);
     #endif

--- a/src/pages/index/StatusTile.cpp
+++ b/src/pages/index/StatusTile.cpp
@@ -44,7 +44,7 @@
     www.sendContent(temp);
 
     #if STAT_MAINS_SENSE != OFF
-      getStatusMainsSenseStr(temp1);
+      if (sense.isOn(STAT_MAINS_SENSE)) strcpy(temp1, "GOOD"); else strcpy(temp1, "OUT"); 
       sprintf_P(temp, htmlInnerStatusMains, temp1);
       www.sendContent(temp);
     #endif

--- a/src/pages/index/StatusTile.cpp
+++ b/src/pages/index/StatusTile.cpp
@@ -44,7 +44,6 @@
     www.sendContent(temp);
 
     #if STAT_MAINS_SENSE != OFF
-      getStatusMainsSenseStr(temp1);
       sprintf_P(temp, htmlInnerStatusMains, temp1);
       www.sendContent(temp);
     #endif


### PR DESCRIPTION
Addresses Issue #32.
Default behavior is unchanged. When configured mains failure event does not count towards the Safety status until the set delay time has expired.
Also found a leftover stray line in StatusTile.cpp that prevented compilation.