### PR TITLE
Fix typo call to wrong libApp

### DIFF
--- a/src/observatory/thermostat/Thermostat.command.cpp
+++ b/src/observatory/thermostat/Thermostat.command.cpp
@@ -5,7 +5,7 @@
 
 #ifdef THERMOSTAT_PRESENT
 
-#include "../../libApp/weatherSensor/WeatherSensor.h"
+#include "../../libApp/thermostatSensor/ThermostatSensor.h"
 #include "../../libApp/relay/Relay.h"
 
 bool Thermostat::command(char reply[], char command[], char parameter[], bool *supressFrame, bool *numericReply, CommandError *commandError) {


### PR DESCRIPTION
Noticed that Thermostat.command.cpp #includes the WeatherSensor.h instead of ThermostatSensor.h
I guess it was working as ThermostatSensor is (I think) a subset of WeatherSensor.