### PR TITLE
Fixes #36 - added commandErrorStr from OnStepX

### DIFF
--- a/src/libApp/commands/ProcessCmds.cpp
+++ b/src/libApp/commands/ProcessCmds.cpp
@@ -15,6 +15,44 @@
   #include "../serial/Serial_Local.h"
 #endif
 
+#if DEBUG != OFF
+  #define L_CE_NONE                    "no errors"
+  #define L_CE_1                       "no error true"
+  #define L_CE_0                       "no error false/fail"
+  #define L_CE_CMD_UNKNOWN             "command unknown"
+  #define L_CE_REPLY_UNKNOWN           "invalid reply"
+  #define L_CE_PARAM_RANGE             "parameter out of range"
+  #define L_CE_PARAM_FORM              "bad parameter format"
+  #define L_CE_ALIGN_FAIL              "align failed"
+  #define L_CE_ALIGN_NOT_ACTIVE        "align not active"
+  #define L_CE_NOT_PARKED_OR_AT_HOME   "not parked or at home"
+  #define L_CE_PARKED                  "already parked"
+  #define L_CE_PARK_FAILED             "park failed"
+  #define L_CE_NOT_PARKED              "not parked"
+  #define L_CE_NO_PARK_POSITION_SET    "no park position set"
+  #define L_CE_SLEW_FAIL               "goto failed"
+  #define L_CE_LIBRARY_FULL            "library full"
+  #define L_CE_SLEW_ERR_BELOW_HORIZON  "goto below horizon"
+  #define L_CE_SLEW_ERR_ABOVE_OVERHEAD "goto above overhead"
+  #define L_CE_SLEW_ERR_IN_STANDBY     "slew in standby"
+  #define L_CE_SLEW_ERR_IN_PARK        "slew in park"
+  #define L_CE_SLEW_ERR_SLEW           "already in goto"
+  #define L_CE_SLEW_ERR_OUTSIDE_LIMITS "outside limits"
+  #define L_CE_SLEW_ERR_HARDWARE_FAULT "hardware fault"
+  #define L_CE_MOUNT_IN_MOTION         "mount in motion"
+  #define L_CE_SLEW_ERR_UNSPECIFIED    "other"
+  #define L_CE_UNK                     "unknown"
+
+  static const char commandErrorStr[26][25] = {
+  L_CE_NONE, L_CE_1, L_CE_0, L_CE_CMD_UNKNOWN, L_CE_REPLY_UNKNOWN, L_CE_PARAM_RANGE,
+  L_CE_PARAM_FORM, L_CE_ALIGN_FAIL, L_CE_ALIGN_NOT_ACTIVE, L_CE_NOT_PARKED_OR_AT_HOME,
+  L_CE_PARKED, L_CE_PARK_FAILED, L_CE_NOT_PARKED, L_CE_NO_PARK_POSITION_SET, L_CE_SLEW_FAIL,
+  L_CE_LIBRARY_FULL, L_CE_SLEW_ERR_BELOW_HORIZON, L_CE_SLEW_ERR_ABOVE_OVERHEAD,
+  L_CE_SLEW_ERR_IN_STANDBY, L_CE_SLEW_ERR_IN_PARK, L_CE_SLEW_ERR_SLEW, L_CE_SLEW_ERR_OUTSIDE_LIMITS,
+  L_CE_SLEW_ERR_HARDWARE_FAULT, L_CE_MOUNT_IN_MOTION, L_CE_SLEW_ERR_UNSPECIFIED, L_CE_UNK
+  };
+#endif
+
 // command processors
 #ifdef SERIAL_A
   CommandProcessor processCommandsA(SERIAL_A_BAUD_DEFAULT,'A');


### PR DESCRIPTION
As per title. Blind copy from OnStepX but seems to align with the OCS commandError enum and compiles. Have not tested in anger yet.
Fixes #36.