### PR TITLE
Metric + mph for GB

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -33,7 +33,7 @@
 #define SERIAL_ONSTEP                 OFF //    OFF, Serial1, NETWORK_STATION, etc. specify serial interface to OnStep.       Option
 
 // DISPLAY -------------------------------------------------------------------------------------------------------------------------
-#define DISPLAY_LANGUAGE             L_en //   L_en, English. L_en, L_us (for IMPERIAL units) two letter country code.        Adjust
+#define DISPLAY_LANGUAGE             L_en //   L_en, Eng. L_us (IMPERIAL units), L_gb (MIXED units), two letter country code. Adjust
 #define CAMERA_WEBPAGE                 "" //     "", To enable add string with web address to camera image display page.      Adjust
 
 // WATCHDOG SETTINGS ---------------------------------------------------------------------------------------------------------------

--- a/src/locales/Locale.h
+++ b/src/locales/Locale.h
@@ -30,6 +30,10 @@
   #include "Strings_es.h"
   #define UNITS METRIC
 #endif
+#if DISPLAY_LANGUAGE == L_gb // not ISO639-1 but might be useful
+  #include "Strings_en.h"
+  #define UNITS BRITISH
+#endif
 
 // misc. locale support functions
 #ifndef DISPLAY_UNITS

--- a/src/pages/index/WeatherTile.cpp
+++ b/src/pages/index/WeatherTile.cpp
@@ -167,7 +167,7 @@
       if (isnan(f)) {
         strcpy_P(temp, htmlStringInvalid);
       } else {
-        #if DISPLAY_UNITS == IMPERIAL
+        #if DISPLAY_UNITS == IMPERIAL || DISPLAY_UNITS == BRITISH
           sprintF(temp, "%6.0f mph", f*0.621371);
         #else
           sprintF(temp, "%6.0f kph", f);


### PR DESCRIPTION
Background - Every country has things that look completely stupid from the outside. Here in the Britain our use of measurement units is still a terrible mix of metric and imperial. The actual choice of units varies by generation but generally/semi-officially most things are metric. A notable exception is that speeds are still in mph for most cases, such as our road signs and weather forecast wind speeds.

This PR adds a L_gb language choice that is the same as L_en except for wind speed being shown in mph.