### PR TITLE
Auto close plugin

### DIFF
--- a/src/plugins/AutoClose/AutoClose.cpp
+++ b/src/plugins/AutoClose/AutoClose.cpp
@@ -4,7 +4,7 @@
 
 void autoCloseWrapper() { autoClose.poll(); }
 
-bool validTime() { return (now() < 315360000); }
+bool isTimeValid() { return (now() < 315360000); }
 
 void AutoClose::init() {
     VF("MSG: AutoClose, start monitor task (rate 1s priority 3)... ");
@@ -19,7 +19,7 @@ void AutoClose::updateWarningOutput() {
         return;
     }
     unsigned long now = millis();
-    unsigned long interval = lastIsSafe ? 2000 : 500;
+    unsigned long interval = lastIsSafe ? 2000 : 250;
     if (now - lastToggle >= interval) {
         outputState = !outputState;
         digitalWrite(AUTOCLOSE_OUTPUT_PIN, outputState ? AUTOCLOSE_OUTPUT_ON : !AUTOCLOSE_OUTPUT_ON);
@@ -37,6 +37,7 @@ bool AutoClose::isSafe() {
         } else {
             if (delayForMains < STAT_MAINS_SAFETY_DELAY) delayForMains++; else safe = false;
         }
+        safetyDeviceCount++;
     #endif
 
     #ifdef WEATHER_PRESENT
@@ -68,45 +69,62 @@ bool AutoClose::isSafe() {
     #endif
     if (safetyDeviceCount == 0) safe = false;
     lastIsSafe = safe;
-    if (overrideEnabled) return false; // block isSafe if override is on
     return safe;
 }
 
 void AutoClose::poll() {
     // Duplicate Safety::poll() logic for autoclose, but only if ROOF_AUTOCLOSE_SAFETY == OFF
     #if defined(ROOF_PRESENT) && (ROOF_AUTOCLOSE_SAFETY == OFF)
-        if (roofAutoClose && validTime()) {
+    if (!overrideEnabled) {    
+      if (roofAutoClose && isTimeValid()) {
             if (hour() == 8 && !roofAutoCloseInitiated) {
                 roofAutoCloseInitiated = true;
                 roof.close();
             }
             if (hour() != 8) roofAutoCloseInitiated = false;
         }
+      if (!isSafe()) {
+        // if the roof isn't closed, and motion is idle, close it
+        if (!roof.isClosed() && !roof.isMoving()) roof.close();
+      }
+    }
     #endif
     updateWarningOutput();
 }
 
 bool AutoClose::command(char *reply, char *command, char *parameter, bool *supressFrame, bool *numericReply, CommandError *commandError) {
-    // Accepts :SO0# or :SO1#
-    if (command && strncmp(command, "SO", 2) == 0 && (command[2] == '0' || command[2] == '1') && command[3] == '#') {
-        roofAutoClose = (command[2] == '1');
-        snprintf(reply, 32, ":SO%d#", roofAutoClose ? 1 : 0);
-        return true;
+
+    if (command[0] == 'S' && command[1] == 'O' && command[2] == 0) {
+        // :SO0# or :SO1#
+        if (parameter[0] == '0' && parameter[1] == 0) {
+            overrideEnabled = false;
+            strcpy(reply, "OFF");
+            *supressFrame = false;
+            *numericReply = false;
+            return true;
+        } else if (parameter[0] == '1' && parameter[1] == 0) {
+            overrideEnabled = true;
+            strcpy(reply, "ON");
+            *supressFrame = false;
+            *numericReply = false;
+            return true;
+        } else {
+            *commandError = CE_PARAM_FORM;
+            return false;
+        }
+    } else if (command[0] == 'G' && command[1] == 'O' && command[2] == 0) {
+        // :GO#
+        if (parameter[0] == 0) {
+            strcpy(reply, overrideEnabled ? "ON" : "OFF");
+            *supressFrame = false;
+            *numericReply = false;
+            return true;
+        } else {
+            *commandError = CE_PARAM_FORM;
+            return false;
+        }
     }
-        return true;
-    }
-    if (strcmp(command, ":GO#") == 0) {
-        *supressFrame = false;
-        *numericReply = false;
-        strcpy(reply, overrideEnabled ? "Override=1" : "Override=0");
-        return true;
-    }
-    UNUSED(*reply);
-    UNUSED(*command);
-    UNUSED(*parameter);
-    UNUSED(*supressFrame);
-    UNUSED(*numericReply);
-    UNUSED(*commandError);
+    // Not handled
     return false;
 }
 

--- a/src/plugins/AutoClose/AutoClose.cpp
+++ b/src/plugins/AutoClose/AutoClose.cpp
@@ -1,6 +1,5 @@
 // AutoClose plugin
 #include "AutoClose.h"
-#ifdef AUTOCLOSE_PLUGIN
 #include <TimeLib.h>
 
 void autoCloseWrapper() { autoClose.poll(); }
@@ -88,12 +87,12 @@ void AutoClose::poll() {
 }
 
 bool AutoClose::command(char *reply, char *command, char *parameter, bool *supressFrame, bool *numericReply, CommandError *commandError) {
-    if (strcmp(command, ":SO#") == 0) {
-        int val = atoi(parameter);
-        overrideEnabled = (val == 1);
-        *supressFrame = false;
-        *numericReply = false;
-        strcpy(reply, overrideEnabled ? "Override Enabled" : "Override Disabled");
+    // Accepts :SO0# or :SO1#
+    if (command && strncmp(command, "SO", 2) == 0 && (command[2] == '0' || command[2] == '1') && command[3] == '#') {
+        roofAutoClose = (command[2] == '1');
+        snprintf(reply, 32, ":SO%d#", roofAutoClose ? 1 : 0);
+        return true;
+    }
         return true;
     }
     if (strcmp(command, ":GO#") == 0) {
@@ -112,4 +111,3 @@ bool AutoClose::command(char *reply, char *command, char *parameter, bool *supre
 }
 
 AutoClose autoClose;
-#endif

--- a/src/plugins/AutoClose/AutoClose.cpp
+++ b/src/plugins/AutoClose/AutoClose.cpp
@@ -1,0 +1,115 @@
+// AutoClose plugin
+#include "AutoClose.h"
+#ifdef AUTOCLOSE_PLUGIN
+#include <TimeLib.h>
+
+void autoCloseWrapper() { autoClose.poll(); }
+
+bool validTime() { return (now() < 315360000); }
+
+void AutoClose::init() {
+    VF("MSG: AutoClose, start monitor task (rate 1s priority 3)... ");
+    pinMode(AUTOCLOSE_OUTPUT_PIN, OUTPUT);
+    digitalWrite(AUTOCLOSE_OUTPUT_PIN, !AUTOCLOSE_OUTPUT_ON); // Ensure off
+    if (tasks.add(100, 0, true, 3, autoCloseWrapper, "AutoClose")) { VLF("success"); } else { VLF("FAILED!"); }
+}
+void AutoClose::updateWarningOutput() {
+    if (!overrideEnabled) {
+        digitalWrite(AUTOCLOSE_OUTPUT_PIN, !AUTOCLOSE_OUTPUT_ON);
+        outputState = false;
+        return;
+    }
+    unsigned long now = millis();
+    unsigned long interval = lastIsSafe ? 2000 : 500;
+    if (now - lastToggle >= interval) {
+        outputState = !outputState;
+        digitalWrite(AUTOCLOSE_OUTPUT_PIN, outputState ? AUTOCLOSE_OUTPUT_ON : !AUTOCLOSE_OUTPUT_ON);
+        lastToggle = now;
+    }
+}
+
+bool AutoClose::isSafe() {
+    bool safe = true;
+    int safetyDeviceCount = 0;
+
+    #if STAT_MAINS_SENSE != OFF
+        if (sense.isOn(STAT_MAINS_SENSE)) {
+            delayForMains = 0;
+        } else {
+            if (delayForMains < STAT_MAINS_SAFETY_DELAY) delayForMains++; else safe = false;
+        }
+    #endif
+
+    #ifdef WEATHER_PRESENT
+        float f;
+        UNUSED(f);
+
+        #if WEATHER_RAIN == ON
+            f = weatherSensor.rain();
+            if (isnan(f) || f < 2.0F) safe = false;
+            safetyDeviceCount++;
+        #endif
+        #if WEATHER_CLOUD_CVR == ON
+            f = weather.getAvgSkyDiffTemp();
+            if (isnan(f) || f < -200 || f > WEATHER_SAFE_THRESHOLD) safe = false;
+            safetyDeviceCount++;
+        #endif
+        #if WEATHER_WIND_SPD == ON
+            f = weatherSensor.windspeed();
+            if (isnan(f) || f < 0 || f > WEATHER_WIND_SPD_THRESHOLD) safe = false;
+            #if WEATHER_WIND_ACCUMULATE > 0
+                if (!isnan(f) && f > WEATHER_WIND_SPD_THRESHOLD && wa < waMax) wa += (f * WEATHER_WIND_ACCUMULATE);
+                if (wa > waMax) wa = waMax;
+                if (!isnan(f) && f <= WEATHER_WIND_SPD_THRESHOLD && wa > 0) wa -= ((WEATHER_WIND_SPD_THRESHOLD - f) / WEATHER_WIND_ACCUMULATE);
+                if (wa < 0) wa = 0;
+                if (wa > 0) safe = false;
+            #endif
+            safetyDeviceCount++;
+        #endif
+    #endif
+    if (safetyDeviceCount == 0) safe = false;
+    lastIsSafe = safe;
+    if (overrideEnabled) return false; // block isSafe if override is on
+    return safe;
+}
+
+void AutoClose::poll() {
+    // Duplicate Safety::poll() logic for autoclose, but only if ROOF_AUTOCLOSE_SAFETY == OFF
+    #if defined(ROOF_PRESENT) && (ROOF_AUTOCLOSE_SAFETY == OFF)
+        if (roofAutoClose && validTime()) {
+            if (hour() == 8 && !roofAutoCloseInitiated) {
+                roofAutoCloseInitiated = true;
+                roof.close();
+            }
+            if (hour() != 8) roofAutoCloseInitiated = false;
+        }
+    #endif
+    updateWarningOutput();
+}
+
+bool AutoClose::command(char *reply, char *command, char *parameter, bool *supressFrame, bool *numericReply, CommandError *commandError) {
+    if (strcmp(command, ":SO#") == 0) {
+        int val = atoi(parameter);
+        overrideEnabled = (val == 1);
+        *supressFrame = false;
+        *numericReply = false;
+        strcpy(reply, overrideEnabled ? "Override Enabled" : "Override Disabled");
+        return true;
+    }
+    if (strcmp(command, ":GO#") == 0) {
+        *supressFrame = false;
+        *numericReply = false;
+        strcpy(reply, overrideEnabled ? "Override=1" : "Override=0");
+        return true;
+    }
+    UNUSED(*reply);
+    UNUSED(*command);
+    UNUSED(*parameter);
+    UNUSED(*supressFrame);
+    UNUSED(*numericReply);
+    UNUSED(*commandError);
+    return false;
+}
+
+AutoClose autoClose;
+#endif

--- a/src/plugins/AutoClose/AutoClose.h
+++ b/src/plugins/AutoClose/AutoClose.h
@@ -40,10 +40,9 @@ private:
     int delayForMains = 0;
     float wa = 0;
     float waMax = 600;
-    // Blocker logic
+
     bool overrideEnabled = false;
     bool lastIsSafe = true;
-    // Output warning logic
     unsigned long lastToggle = 0;
     bool outputState = false;
     void updateWarningOutput();

--- a/src/plugins/AutoClose/AutoClose.h
+++ b/src/plugins/AutoClose/AutoClose.h
@@ -1,4 +1,16 @@
 // AutoClose plugin
+
+/* This plugin replaces the existing roof auto-close functionality with a version
+*  that allows the user to disable auto-closing of the roof by sending a command.
+*  The intended use is for when the observatory is manned and being dubugged where
+*  the user does not want the roof to close automatically on bad weather conditions,
+*  but still wants to monitor the weather conditions and have the ability to enable
+*  auto-closing when desired.
+*  A definable output pin is also provided to allow for a warning light that the auto
+*  close is disabled and current safety status.
+*/
+
+
 #pragma once
 
 #include "../../lib/commands/CommandErrors.h"
@@ -10,15 +22,8 @@
 #include "../../observatory/roof/Roof.h"
 
 // User configuration for warning output
-#ifndef AUTOCLOSE_OUTPUT_PIN
-#define AUTOCLOSE_OUTPUT_PIN RELAY16_PIN // Set to desired output pin
-#endif
-#ifndef AUTOCLOSE_OUTPUT_ON
-#define AUTOCLOSE_OUTPUT_ON HIGH // Set to HIGH or LOW for ON state
-#endif
-
-// Enable this plugin by defining AUTOCLOSE_PLUGIN in Config.h or build flags
-#ifdef AUTOCLOSE_PLUGIN
+#define AUTOCLOSE_OUTPUT_PIN    OFF // Set to pin number or OFF to disable
+#define AUTOCLOSE_OUTPUT_ON    HIGH // Set to HIGH or LOW for ON state
 
 class AutoClose {
 public:
@@ -45,5 +50,3 @@ private:
 };
 
 extern AutoClose autoClose;
-
-#endif

--- a/src/plugins/AutoClose/AutoClose.h
+++ b/src/plugins/AutoClose/AutoClose.h
@@ -1,0 +1,49 @@
+// AutoClose plugin
+#pragma once
+
+#include "../../lib/commands/CommandErrors.h"
+#include "../../Common.h"
+#include "../../lib/tasks/OnTask.h"
+#include "../../lib/sense/Sense.h"
+#include "../../libApp/weatherSensor/WeatherSensor.h"
+#include "../../observatory/weather/Weather.h"
+#include "../../observatory/roof/Roof.h"
+
+// User configuration for warning output
+#ifndef AUTOCLOSE_OUTPUT_PIN
+#define AUTOCLOSE_OUTPUT_PIN RELAY16_PIN // Set to desired output pin
+#endif
+#ifndef AUTOCLOSE_OUTPUT_ON
+#define AUTOCLOSE_OUTPUT_ON HIGH // Set to HIGH or LOW for ON state
+#endif
+
+// Enable this plugin by defining AUTOCLOSE_PLUGIN in Config.h or build flags
+#ifdef AUTOCLOSE_PLUGIN
+
+class AutoClose {
+public:
+    void init();
+    void loop();
+    bool isSafe();
+    float gustCount() { return wa; }
+    void poll();
+    bool roofAutoClose = false;
+    // Command interface
+    bool command(char *reply, char *command, char *parameter, bool *supressFrame, bool *numericReply, CommandError *commandError);
+private:
+    bool roofAutoCloseInitiated = false;
+    int delayForMains = 0;
+    float wa = 0;
+    float waMax = 600;
+    // Blocker logic
+    bool overrideEnabled = false;
+    bool lastIsSafe = true;
+    // Output warning logic
+    unsigned long lastToggle = 0;
+    bool outputState = false;
+    void updateWarningOutput();
+};
+
+extern AutoClose autoClose;
+
+#endif


### PR DESCRIPTION
This adds a plugin that provides a modified AutoClose when unsafe feature. When used the default ROOF_AUTOCLOSE_SAFETY must be defined as OFF in the Config.h
It works the same as the default implementation with the following exceptions:
The function can be overridden by command :SO1# and :SO0# (set override).
When the override is enabled and therefore an unsafe condition will not AutoClose the roof an LED, or other output) can be defined as AUTOCLOSE_OUTPUT_PIN in the plugin. This will then flash every two seconds as a warning that the override is enabled when the condition is SAFE, and every 250ms when the condition is UNSAFE.

The purpose of the plugin is to allow manned observatory operation with a failed weather/mains sensor without having to recompile and upload the code.
